### PR TITLE
Continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           # From https://circleci.com/docs/2.0/docker-compose/
           name: Installing Docker Compose
           command: >-
-            DC_VERSION=1.19.0 &&
+            DC_VERSION=1.24.0 &&
             DC_DOWNLOAD=docker-compose-`uname -s`-`uname -m` &&
             curl -Lo ~/docker-compose \
               https://github.com/docker/compose/releases/download/$DC_VERSION/$DC_DOWNLOAD &&
@@ -30,7 +30,7 @@ jobs:
           # The Django start script will run migrations for us
           name: Starting Docker application
           command: >-
-            docker-compose --file local.yml up
+            docker-compose --file local.yml up --detach
       - run:
           name: Checking for missing migrations
           command: >-


### PR DESCRIPTION
This pull request adds a CircleCI configuration file. On every push, CircleCI will:

1. spin up a virtual machine with Docker and Docker Compose installed
2. build the Docker application (`local.yml` only)
3. spin up the Docker application
4. create a test database and execute Django migrations
5. check for any Django model changes that do not have corresponding migrations
6. run Django system checks
7. run Django tests

The file is fairly generic and so it could be added to the [Starterkit](https://github.com/WHOIGit/django-cookiecutter-starterkit) and adopted by other projects.

Technical note: Normally, CircleCI builds projects inside Docker containers, but projects which build *new* Docker containers *and* expect to mount volumes into those containers *must* use the machine executor. Projects which *do not* use Docker Compose and then spin up the built image should not follow this model.