### PR TITLE
duplicate results + unboundlocalerror bugfix for search

### DIFF
--- a/roundabout/search/views.py
+++ b/roundabout/search/views.py
@@ -79,20 +79,22 @@ class BasicSearch(LoginRequiredMixin, ListView):
                 if sn_bool and name_bool: query_inv = Q(serial_number__icontains=keywords)|Q(part__name__icontains=keywords)
                 elif sn_bool:             query_inv = Q(serial_number__icontains=keywords)
                 elif name_bool:           query_inv = Q(part__name__icontains=keywords)
+                else:                     query_inv = Q()
                 if udf_bool:
                     query_inv = query_inv | Q(fieldvalues__field_value__icontains=keywords)
                     query_inv = query_inv | Q(part__user_defined_fields__field_name__icontains=keywords)
                 if loc_bool:
                     query_inv = query_inv | Q(location__name__icontains=keywords)
-                qs_inv = Inventory.objects.filter(query_inv).order_by('serial_number')
+                qs_inv = Inventory.objects.filter(query_inv).order_by('serial_number').distinct()
 
             if parts_bool:
                 if sn_bool and name_bool: query_prt = Q(part_number__icontains=keywords)|Q(name__icontains=keywords)
                 elif sn_bool:             query_prt = Q(part_number__icontains=keywords)
                 elif name_bool:           query_prt = Q(name__icontains=keywords)
+                else:                     query_prt = Q()
                 if udf_bool:              query_prt = query_prt | Q(user_defined_fields__field_name__icontains=keywords)
 
-                try: qs_prt = Part.objects.filter(query_prt).order_by('part_number')
+                try: qs_prt = Part.objects.filter(query_prt).order_by('part_number').distinct()
                 except ValueError: pass
 
         return list(qs_inv) + list(qs_prt)


### PR DESCRIPTION
Fixed issues mentioned in this email.
1) duplicate results of same item
2) error page when only custom fields is selected in search

> Hey Steph,
> I had mentioned yesterday after the meeting that I had briefly tried
> some of the searching in Roundabout and came across a few quirks and
> suggestions.
> 
> One of the searches I tried was for an instrument vendor serial number
> (not the "serial number" or UID per the system). I searched NTR-1064 (a
> NUTNR-B SUNA I'd previously put in the system) and with all of the
> default filters, **it came up with 19 results of the same instrument**. It
> looks like there are 19 custom fields that are set to apply to all
> instruments... not sure if that's related or just coincidence. When I
> tried toggling the searched field parameters on and off, I got zero
> results for everything except custom field, which makes sense in the
> system now given manufacturer serial number is a custom field. However,
> it would be great if there could be an advanced search function where
> you could search or filter by different fields, including individual
> custom fields. In addition, when I had **just the custom field toggled on
> for the search, it came up with the following error page**:
> 

![0](https://user-images.githubusercontent.com/44208509/66948118-18f87080-f022-11e9-9689-f0460433cbc4.png)

> 
> I'll let you know if I come across anything else in further testing.
> 
> Jennifer