### PR TITLE
bugfix for #72 OBS site search issue

### DIFF
--- a/roundabout/userdefinedfields/models.py
+++ b/roundabout/userdefinedfields/models.py
@@ -67,7 +67,7 @@ class FieldValue(models.Model):
         get_latest_by = 'created_at'
 
     def __str__(self):
-        return str(self.field_value)
+        return self.field_value if self.field_value is not None else ''
 
     @property
     def get_field_value(self):

--- a/roundabout/userdefinedfields/models.py
+++ b/roundabout/userdefinedfields/models.py
@@ -67,7 +67,7 @@ class FieldValue(models.Model):
         get_latest_by = 'created_at'
 
     def __str__(self):
-        return self.field_value
+        return str(self.field_value)
 
     @property
     def get_field_value(self):


### PR DESCRIPTION
#72 OBS site search issue

Some udf FieldValue.field_value fields were in the database as `None` and could not be rendered in the table. Changing `FieldValue.__str__()` to return `""` when `FieldValue.field_value==None` fixes this bug. 

The issue was not sorting related, it only so-happened that the UDF's that needed rendering (even in a hidden column) made it to the paginated table after that particular sort.