### PR TITLE
bugfix: filter(str.date) error for Bulk Export: CI

### DIFF
--- a/roundabout/search/tables.py
+++ b/roundabout/search/tables.py
@@ -146,7 +146,7 @@ class ActionTable(SearchTable):
 class CalibrationTable(SearchTable):
     class Meta(SearchTable.Meta):
         model = CalibrationEvent
-        fields = ['inventory__serial_number','inventory__part__name','calibration_date','deployment','approved','user_approver__name','user_drafter__name']
+        fields = ['inventory__serial_number','inventory__part__name','calibration_date','deployment','approved','user_approver__all__name','user_draft__all__name']
         base_shown_cols = ['inventory__serial_number','calibration_date','approved']
 
     inventory__serial_number = Column(verbose_name='Inventory SN', attrs={'style':'white-space: nowrap;'},
@@ -156,8 +156,8 @@ class CalibrationTable(SearchTable):
     calibration_date = DateColumn(verbose_name='Calibration Date', format='Y-m-d',
             linkify=dict(viewname="exports:calibration", args=[tables.A('pk')]))
 
-    user_approver__name = Column(verbose_name='Approver Name')
-    user_drafter__name = Column(verbose_name='Drafter Name')
+    user_approver__all__name = ManyToManyColumn(verbose_name='Approvers', accessor='user_approver', transform=lambda x: x.name, default='')
+    user_draft__all__name = ManyToManyColumn(verbose_name='Reviewers', accessor='user_draft', transform=lambda x: x.name, default='')
 
     coefficient_value_set__names = ManyToManyColumn(verbose_name='Coefficient Names',
             accessor='coefficient_value_sets', transform=lambda x: x.coefficient_name)
@@ -170,7 +170,7 @@ class CalibrationTable(SearchTable):
 class ConfigConstTable(SearchTable):
     class Meta(SearchTable.Meta):
         model = ConfigEvent
-        fields = ['inventory__serial_number','inventory__part__name','configuration_date','deployment','approved','user_approver__name','user_drafter__name']
+        fields = ['inventory__serial_number','inventory__part__name','configuration_date','deployment','approved','user_approver__all__name','user_draft__all__name']
         base_shown_cols = ['inventory__serial_number','configuration_date','approved']
 
     inventory__serial_number = Column(verbose_name='Inventory SN', attrs={'style':'white-space: nowrap;'},
@@ -178,11 +178,11 @@ class ConfigConstTable(SearchTable):
     inventory__part__name = Column(verbose_name='Part',
             linkify=dict(viewname="parts:parts_detail", args=[tables.A('inventory__part__pk')]))
     configuration_date = DateColumn(verbose_name='Event Date', format='Y-m-d',
-            #linkify=dict(viewname="exports:configconst", args=[tables.A('pk')])
+            linkify=dict(viewname="exports:configconst", args=[tables.A('pk')])
             )
 
-    user_approver__name = Column(verbose_name='Approver Name')
-    user_drafter__name = Column(verbose_name='Drafter Name')
+    user_approver__all__name = ManyToManyColumn(verbose_name='Approvers', accessor='user_approver', transform=lambda x: x.name, default='')
+    user_draft__all__name = ManyToManyColumn(verbose_name='Reviewers', accessor='user_draft', transform=lambda x: x.name, default='')
 
     config_values__names = ManyToManyColumn(verbose_name='Config/Constant Names',
             accessor='config_values', transform=lambda x: x.config_name)

--- a/roundabout/search/views.py
+++ b/roundabout/search/views.py
@@ -77,6 +77,7 @@ def searchbar_redirect(request):
         elif model=='part':         getstr = '?f=.0.part_number&f=.0.name&f=.0.friendly_name&l=.0.icontains&q=.0.{query}'
         elif model == 'build':      getstr = '?f=.0.build_number&f=.0.assembly__name&f=.0.assembly__assembly_type__name&f=.0.assembly__description&f=.0.build_notes&f=.0.location__name&l=.0.icontains&q=.0.{query}'
         elif model == 'assembly':   getstr = '?f=.0.assembly_number&f=.0.name&f=.0.assembly_type__name&f=.0.description&l=.0.icontains&q=.0.{query}'
+        elif model == 'action':     getstr = '?f=.0.action_type&f=.0.user__name&f=.0.detail&f=.0.location__name&f=.0.inventory__serial_number&f=.0.inventory__part__name&l=.0.icontains'+'&q=.0.{query}'
         getstr = getstr.format(query=query)
         resp['Location'] += getstr
     return resp
@@ -609,7 +610,7 @@ class ActionTableView(GenericSearchTableView):
                         dict(value="inventory__part__name", text="Inventory: Name", legal_lookup='STR_LOOKUP'),
                         dict(value="build__assembly_revision__assembly__name", text="Build Assembly", legal_lookup='STR_LOOKUP'),
                         dict(value="build__build_number", text="Build Number", legal_lookup='STR_LOOKUP'),
-                        dict(value="deployment__deployment_number", text="Build Number", legal_lookup='STR_LOOKUP'),
+                        dict(value="deployment__deployment_number", text="Deployment Number", legal_lookup='STR_LOOKUP'),
                         dict(value="cruise__CUID", text="Cruise: ID", legal_lookup='STR_LOOKUP'),
                         dict(value="cruise__friendly_name", text="Cruise: Name", legal_lookup='STR_LOOKUP'),
                         ]
@@ -700,3 +701,6 @@ class ConfigConstTableView(GenericSearchTableView):
 
         return {'extra_columns':[]}
 
+# TODO see sn CGINS-DOSTAD-00134 for approver/reviewer search functionality
+# http://0.0.0.0:8000/search/calibrations?f=.0.calibration_event__inventory__serial_number&l=.0.icontains&q=.0.CGINS-DOSTAD-00134
+# http://0.0.0.0:8000/search/inventory?f=.0.serial_number&l=.0.icontains&q=.0.CGINS-DOSTAD-00134


### PR DESCRIPTION
bugfix: filter(str.date) error for "Bulk Export: CI" (the bug from last wednesday's meeting)
bugfix:  duplicate filenames in zip files for bulk exports get annotated. eg: "fname (1).ext"
(this showed up in a corner-case where my test data had a two calibration events for the same instrument on the same date)