### PR TITLE
hotfix-262 search: csv-download bugfix

### DIFF
--- a/roundabout/search/mixins.py
+++ b/roundabout/search/mixins.py
@@ -26,7 +26,7 @@ from tablib import Dataset
 
 class TableExportStream(TableExport):
 
-    def table_to_dataset(self, table, exclude_columns):
+    def table_to_dataset(self, table, exclude_columns, dataset_kwargs=None):
         """A generator that returns a tablib dataset for each row of the table."""
         table_rows = table.as_values(exclude_columns=exclude_columns)
         headers = next(table_rows)


### PR DESCRIPTION
#262 

search/download files for rbd version 1.6 and 1.6.1 were identical. 
The table/export library (django_tables2) must have been updated between the two versions, causing the error. 