### PR TITLE
small fixes for #284

### DIFF
--- a/roundabout/assemblies/views.py
+++ b/roundabout/assemblies/views.py
@@ -220,13 +220,16 @@ class AssemblyAjaxCreateView(LoginRequiredMixin, PermissionRequiredMixin, AjaxFo
             return response
 
     def form_invalid(self, form, documentation_form):
-        form_errors = documentation_form.errors
-
         if self.request.is_ajax():
-            data = form.errors
-            return JsonResponse(data, status=400)
+            if not form.is_valid():
+                # show form errors before formset errors
+                return JsonResponse(form.errors, status=400)
+            else:
+                # only show formset errors if there are no form errors
+                # because it is unclear how to combine form and formset errors in a way that doesnt break project.js:handleFormError()
+                return JsonResponse(documentation_form.errors, status=400, safe=False)
         else:
-            return self.render_to_response(self.get_context_data(form=form, revision_form=revision_form, documentation_form=documentation_form, form_errors=form_errors))
+            return self.render_to_response(self.get_context_data(form=form, documentation_form=documentation_form))
 
     def get_success_url(self):
         return reverse('assemblies:ajax_assemblies_detail', args=(self.object.id,))
@@ -472,13 +475,16 @@ class AssemblyRevisionAjaxCreateView(LoginRequiredMixin, PermissionRequiredMixin
             return response
 
     def form_invalid(self, form, documentation_form):
-        form_errors = documentation_form.errors
-
         if self.request.is_ajax():
-            data = form.errors
-            return JsonResponse(data, status=400)
+            if not form.is_valid():
+                # show form errors before formset errors
+                return JsonResponse(form.errors, status=400)
+            else:
+                # only show formset errors if there are no form errors
+                # because it is unclear how to combine form and formset errors in a way that doesnt break project.js:handleFormError()
+                return JsonResponse(documentation_form.errors, status=400, safe=False)
         else:
-            return self.render_to_response(self.get_context_data(form=form, documentation_form=documentation_form, form_errors=form_errors))
+            return self.render_to_response(self.get_context_data(form=form, documentation_form=documentation_form))
 
     def get_success_url(self):
         return reverse('assemblies:ajax_assemblyrevision_detail', args=(self.object.id,))
@@ -529,13 +535,16 @@ class AssemblyRevisionAjaxUpdateView(LoginRequiredMixin, PermissionRequiredMixin
             return response
 
     def form_invalid(self, form, documentation_form):
-        form_errors = documentation_form.errors
-
         if self.request.is_ajax():
-            data = form.errors
-            return JsonResponse(data, status=400)
+            if not form.is_valid():
+                # show form errors before formset errors
+                return JsonResponse(form.errors, status=400)
+            else:
+                # only show formset errors if there are no form errors
+                # because it is unclear how to combine form and formset errors in a way that doesnt break project.js:handleFormError()
+                return JsonResponse(documentation_form.errors, status=400, safe=False)
         else:
-            return self.render_to_response(self.get_context_data(form=form, documentation_form=documentation_form, form_errors=form_errors))
+            return self.render_to_response(self.get_context_data(form=form, documentation_form=documentation_form))
 
     def get_success_url(self):
         return reverse('assemblies:ajax_assemblyrevision_detail', args=(self.object.id,))

--- a/roundabout/search/tables.py
+++ b/roundabout/search/tables.py
@@ -22,7 +22,8 @@ from random import randint
 
 import django_tables2 as tables
 from django.urls import reverse
-from django.utils.html import format_html, mark_safe
+from django.utils.html import format_html, mark_safe, strip_tags
+from django.utils.text import Truncator
 from django_tables2.columns import Column, DateColumn, DateTimeColumn, ManyToManyColumn
 from django_tables2_column_shifter.tables import ColumnShiftTable
 
@@ -57,24 +58,25 @@ def trunc_render(length=100, safe=False, showable=True, targets=None, bold_targe
             else: output_str = value
         else:
             if target and target.lower() in value.lower():
-                target_idx = value.lower().index(target.lower())
+                value_stripped = strip_tags(value)
+                target_idx = value_stripped.lower().index(target.lower())
                 start_idx,end_idx = target_idx-int(length/2),target_idx+int(length/2)
                 start_idx,end_idx = start_idx+int(len(target)/2), end_idx+int(len(target)/2)
-                if start_idx>0 and end_idx<len(value):
-                    shown_txt = value[start_idx:end_idx]
+                if start_idx>0 and end_idx<len(value_stripped):
+                    shown_txt = value_stripped[start_idx:end_idx]
                     start,end = '▴…','…▾'
                 elif end_idx > len(value):
-                    shown_txt = value[-length:]
+                    shown_txt = value_stripped[-length:]
                     start,end = '▴…',''
                 else:
-                    shown_txt = value[:length]
+                    shown_txt = Truncator(value).chars(length,'',html=True)
                     start,end = '','…▾'
 
                 if bold_target: shown_txt = boldify(shown_txt,target)
 
             else:
                 start,end = '','…▾'
-                shown_txt = value[:length]
+                shown_txt = Truncator(value).chars(length,'',html=True)
 
             if showable: # insert some javascript to show truncated text
                 hidden_id = 'trunc{:05}'.format(randint(0,100000))

--- a/roundabout/templates/assemblies/ajax_assembly_form.html
+++ b/roundabout/templates/assemblies/ajax_assembly_form.html
@@ -1,7 +1,7 @@
 <!--
 # Copyright (C) 2019-2020 Woods Hole Oceanographic Institution
 #
-# This file is part of the Roundabout Database project ("RDB" or 
+# This file is part of the Roundabout Database project ("RDB" or
 # "ooicgsn-roundabout").
 #
 # ooicgsn-roundabout is free software: you can redistribute it and/or modify
@@ -81,26 +81,12 @@
              <tbody>
                {{ documentation_form.management_form }}
 
-               {% if documentation_form.errors %}
-               <tr>
-                 <div class="alert alert-danger">
-                 {% for dict in documentation_form.errors %}
-
-                     {% for error in dict.values %}
-                       {{ error|escape }}
-                     {% endfor %}
-
-                 {% endfor %}
-                 </div>
-               </tr>
-              {% endif %}
-
                {% for doc in documentation_form %}
 
                  <tr>
-                     <td>{% if doc.id  %}{{ doc.DELETE }}{% endif %} {{ doc.id }} {{ doc.name }}</td>
-                     <td class="text-right">{{ doc.doc_type }}</td>
-                     <td class="text-right">{{ doc.doc_link }} </td>
+                     <td {% if doc.errors.name %} class="alert alert-danger"{% endif %}>{% if doc.id  %}{{ doc.DELETE }}{% endif %} {{ doc.id }} {{ doc.name }}</td>
+                     <td {% if doc.errors.doc_type %} class="alert alert-danger"{% endif %}>{{ doc.doc_type }}</td>
+                     <td {% if doc.errors.doc_link %} class="alert alert-danger"{% endif %}>{{ doc.doc_link }} </td>
                  </tr>
                {% endfor %}
              </tbody>

--- a/roundabout/templates/cruises/vessel_list.html
+++ b/roundabout/templates/cruises/vessel_list.html
@@ -78,7 +78,7 @@
               <td>
                 {% if vessel.hyperlinks %}
                   {% for link in vessel.hyperlinks.all %}
-                    <a href="{{ link.url }}">{{ link.text }} <i class="fas fa-link"></i></a><br>
+                    <a target="_blank" href="{{ link.url }}">{{ link.text }} <i class="fas fa-link"></i></a><br>
                   {% endfor %}
                 {% endif %}
               </td>


### PR DESCRIPTION
addresses latest comments on #284 

> 1. Vessel links are the only ones that open in the working tab. The others open in a new tab. I prefer the "open in a new tab" option, and would choose it for the Vessel links, if that's possible.
> 2. For ATs, leaving the "Document Type" field unselected prevents entry from being accepted, but there's no error/feedback that this field is required. I know the links for ATs are a legacy implementation, and don't come from your work here Sidney, but wanted to mention it here.