### PR TITLE
#487 attempted fixes for security risks (high risk 1 and 3)

### DIFF
--- a/roundabout/tags/forms.py
+++ b/roundabout/tags/forms.py
@@ -56,6 +56,8 @@ class TagForm(forms.ModelForm):
             raise ValidationError(_('Formatting braces "{}" must be empty'), code='invalid')
         if len(field_names) > 2 or sum([1 for fn in field_names if fn == '']) >= 2:
             raise ValidationError(_('Only one set of "{}" braces allowed'), code='invalid')
+        if '>' in data or '<' in data:
+            raise ValidationError(_('The following characters are not allowed: <>'), code='invalid')
         return data
 
     def clean(self):

--- a/roundabout/tags/views.py
+++ b/roundabout/tags/views.py
@@ -28,6 +28,7 @@ from django.http import HttpResponseRedirect, HttpResponse, JsonResponse
 from django.views.generic import View, FormView, DetailView, ListView, RedirectView, UpdateView, CreateView, DeleteView, TemplateView
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin
 from django.core.exceptions import ValidationError
+from django.shortcuts import redirect
 
 from .models import Tag
 from .forms import TagForm
@@ -46,7 +47,11 @@ class TagAjaxCreateView(LoginRequiredMixin, PermissionRequiredMixin, AjaxFormMix
     def get(self, request, *args, **kwargs):
         self.object = None
         assemblypart_id = request.GET.get('a')
-        assembly_part = AssemblyPart.objects.get(id=assemblypart_id) if assemblypart_id else None
+        try:
+            assembly_part = AssemblyPart.objects.get(id=assemblypart_id)
+        except (ValueError,AssemblyPart.DoesNotExist):
+            return redirect(request.META.get('HTTP_REFERER', '/'))
+
         self.initial.update(assembly_part=assembly_part, text='{}')
         form = self.get_form()
         return self.render_to_response(self.get_context_data(assembly_part=assembly_part, form=form))

--- a/roundabout/templates/search/adv_search.html
+++ b/roundabout/templates/search/adv_search.html
@@ -30,30 +30,34 @@
 
 {% block javascript %}
   <script type="text/javascript" src="/static/js/form-search.js"></script>
+  {{ prev_cards|json_script:'prev_cards' }}
+  {{ avail_fields|json_script:'avail_fields' }}
+  {{ avail_lookups|json_script:'avail_lookups' }}
+  {{ lookup_categories|json_script:'lookup_categories' }}
   <script>
     const page_model = '{{ model }}'
 
     {% if prev_cards %}
-    const prev_cards = jQuery.parseJSON("{{ prev_cards|escapejs }}")
+    const prev_cards = JSON.parse(document.getElementById('prev_cards').textContent)
     {% else %}
     const prev_cards = null
     {% endif %}
 
     {% if avail_fields %}
-    const avail_fields = jQuery.parseJSON("{{ avail_fields|escapejs }}")
+    const avail_fields = JSON.parse(document.getElementById('avail_fields').textContent)
     {% else %}
     const avail_fields = [{value:'id',text:'Database ID',disabled:false, legal_lookup:'BOOL_LOOKUP'}]
     {% endif %}
 
     {% if avail_lookups %}
-    const avail_lookups = jQuery.parseJSON("{{ avail_lookups|escapejs }}")
+    const avail_lookups = JSON.parse(document.getElementById('avail_lookups').textContent)
     {% else %}
     const avail_lookups = [{value: "icontains", text: "Contains"},
                            {value:     "exact", text:    "Exact"}]
     {% endif %}
 
     {% if lookup_categories %}
-    const lookup_categories = jQuery.parseJSON("{{ lookup_categories|escapejs }}")
+    const lookup_categories = JSON.parse(document.getElementById('lookup_categories').textContent)
     {% else %}
     const lookup_categories = {STR_LOOKUP : ['icontains', 'exact'],
                                NUM_LOOKUP : ['exact','gte','lte'],


### PR DESCRIPTION
removed template calls to |escapejs in favor of |json_script
Some of the security risks I think was just the server throwing an error when an invalid value was being sent to it. like a string (malicious or benign) instead of an integer for a model id. I addressed this for search by defaulting such errors to either redirecting to a safe page, or returning an empty query.