### PR TITLE
OBS assembly-builds export feature

### DIFF
--- a/roundabout/assemblies/models.py
+++ b/roundabout/assemblies/models.py
@@ -56,6 +56,11 @@ class Assembly(models.Model):
     def get_object_type(self):
         return 'assemblies'
 
+    def has_nontrashed_nonretired_builds(self):
+        for build in self.builds.all():
+            if build.location.get_root().root_type == 'Retired': continue
+            if build.location.get_root().root_type == 'Trash': continue
+            return True
 
 class AssemblyRevision(models.Model):
     revision_code = models.CharField(max_length=255, unique=False, db_index=True, default='A')

--- a/roundabout/exports/urls.py
+++ b/roundabout/exports/urls.py
@@ -35,4 +35,6 @@ urlpatterns = [
     path('vessels/', view=views.ExportVessels.as_view(), name='vessels'),
     path('deployments/', view=views.ExportDeployments.as_view(), name='deployments'),
     path('CI/', view=views.ExportCI.as_view(), name='CI'),
+    path('obs_assemblybuilds/<int:pk>', view=views.ExportOBSAssemblyBuilds.as_view(), name='obs_assemblybuilds'),
+    path('obs_allbuilds', view=views.ExportOBSBuildsAll.as_view(), name='obs_allbuilds'),
 ]

--- a/roundabout/templates/assemblies/ajax_assembly_detail.html
+++ b/roundabout/templates/assemblies/ajax_assembly_detail.html
@@ -46,6 +46,8 @@
                     data-detail-url="{% url 'assemblies:ajax_assemblies_copy' assembly.id %}"
                     data-node-id="{{ assembly.id }}"
                     data-node-type="{{ node_type }}">Copy {{ label_assemblies_app_singular }} Template</a>
+                <button class="dropdown-item" onclick='location.href="{% url 'exports:obs_assemblybuilds' assembly.id %}";' {% if not assembly.has_nontrashed_nonretired_builds %}disabled{% endif %}
+                  >Export {{ label_assemblies_app_singular }}-{{ label_builds_app_plural }} CSV [OBS]</button>
             </div>
 
       </div>

--- a/roundabout/templates/exports/home.html
+++ b/roundabout/templates/exports/home.html
@@ -37,7 +37,7 @@
       <br><br><a type=button class="btn btn-primary" href="{% url 'exports:configconsts' %}">Export Configurations & Constants</a>
       <br><br><a type=button class="btn btn-primary" href="{% url 'exports:calibrations_with_configs' %}">Export Calibrations with<br>Configurations and Constants</a>
       <br><br><a type=button class="btn btn-primary" href="{% url 'exports:CI' %}">Export All [CI]</a>
-
+      <br><br><a type=button class="btn btn-primary" href="{% url 'exports:obs_allbuilds' %}">Export Builds [OBS]</a>
     </div>
     <div class="col-md-7">
 


### PR DESCRIPTION
Added a feature allowing the export of an assembly-template's builds' serial-numbers, as a CSV. 
CSV columns follow the assembly-template's nested assembly-part order. 
It can be accessed via a Choose Action button on Assembly detail view interface.
CSVs for all assemblies can be downloaded in bulk from Bulk Downloads interface. 

This feature was requested by OBS.