### PR TITLE
obs-export-patch for Q330

### DIFF
--- a/roundabout/exports/views.py
+++ b/roundabout/exports/views.py
@@ -727,24 +727,24 @@ class ExportOBSAssemblyBuilds(DetailView,LoginRequiredMixin):
                     ar_disable = vals.get(field__field_name__icontains='Disable').field_value
                     ar_burn1 = vals.get(field__field_name__icontains='Burn 1').field_value
                     ar_option = vals.get(field__field_name__icontains='Option').field_value
-                    nested_update(data, inv_lineage_keys+['Enable'], row_num, ar_enable)
-                    nested_update(data, inv_lineage_keys+['Disable'], row_num, ar_disable)
-                    nested_update(data, inv_lineage_keys+['Burn1'], row_num, ar_burn1)
-                    nested_update(data, inv_lineage_keys+['Option'], row_num, ar_option)
+                    nested_update(data, inv_lineage_keys+[' Enable'], row_num, ar_enable)
+                    nested_update(data, inv_lineage_keys+[' Disable'], row_num, ar_disable)
+                    nested_update(data, inv_lineage_keys+[' Burn1'], row_num, ar_burn1)
+                    nested_update(data, inv_lineage_keys+[' Option'], row_num, ar_option)
 
                 elif part.startswith('Q330'):
                     vals = inv.fieldvalues.filter(is_current=True)
                     q330_idsn = field_safeget(vals,'Q330 Tag ID / SN')
                     q330_lsn = field_safeget(vals,'Q330 Long Serial Number')
                     q330_ip = field_safeget(vals,'Q330 IP')
-                    nested_update(data, inv_lineage_keys + ['Q330: Tag ID/SN'], row_num, q330_idsn)
-                    nested_update(data, inv_lineage_keys + ['Q330: Long S/N'], row_num, q330_lsn)
-                    nested_update(data, inv_lineage_keys + ['Q330: IP'], row_num, q330_ip)
+                    nested_update(data, inv_lineage_keys + [' Q330: Tag ID/SN'], row_num, q330_idsn)
+                    nested_update(data, inv_lineage_keys + [' Q330: Long S/N'], row_num, q330_lsn)
+                    nested_update(data, inv_lineage_keys + [' Q330: IP'], row_num, q330_ip)
 
                 elif part.startswith('Baler 14'):
                     vals = inv.fieldvalues.filter(is_current=True)
                     baller_tag = field_safeget(vals,'Baler Tag')
-                    nested_update(data, inv_lineage_keys + ['Baler 14: Tag'], row_num, baller_tag)
+                    nested_update(data, inv_lineage_keys + [' Baler 14: Tag'], row_num, baller_tag)
 
         # format data to rows
         def nested_unpack2cols(d):


### PR DESCRIPTION
for the obs export csv, the custom fields for Q330 are appearing after other sub-assemblied child-to Q330. The custom fields should appear directly after Q330. Since items child-to assemblies are alphabetically ordered when serialized to csv, prepending a whitespace to the Q330 custom fields should fix this minor bug.
Although other subassemblies with special-case custom field inclusion don't seem to have child subassemblies, the custom field prepended whitespace is added to the other custom fields to avoid any future ordering issues of this sort.