### PR TITLE
Deployment Import RefDes Hotfix

### DIFF
--- a/roundabout/ooi_ci_tools/tasks.py
+++ b/roundabout/ooi_ci_tools/tasks.py
@@ -769,8 +769,15 @@ def parse_deployment_files(self):
                         assembly_part.assembly = assembly
                         assembly_part.save()
                         item.assembly_part = assembly_part
-                    refdes_event = ref_des_obj.refdes_events.first()
-                    refdes_event.assembly_part = assembly_part
+                        item.save()
+                    try:
+                        refdes_event = ref_des_obj.assembly_part.assemblypart_referencedesignatorevents.first()
+                    except Exception as e:
+                        refdes_event = ReferenceDesignatorEvent.objects.create(
+                            reference_designator = ref_des_obj,
+                            assembly_part = assembly_part
+                        )
+                    refdes_event.assembly_part = item.assembly_part
                     refdes_event.save()
                     item.location = build_location
                     item.build = build

--- a/roundabout/ooi_ci_tools/tasks.py
+++ b/roundabout/ooi_ci_tools/tasks.py
@@ -775,7 +775,7 @@ def parse_deployment_files(self):
                     except Exception as e:
                         refdes_event = ReferenceDesignatorEvent.objects.create(
                             reference_designator = ref_des_obj,
-                            assembly_part = assembly_part
+                            assembly_part = item.assembly_part
                         )
                     refdes_event.assembly_part = item.assembly_part
                     refdes_event.save()


### PR DESCRIPTION
If AssemblyParts are deleted, the ReferenceDesignatorEvent is also deleted. The Deployment importer can now handle cases where Events are missing.