### PR TITLE
Automated tests

### DIFF
--- a/.github/workflows/zap-publish-image-rdb.yml
+++ b/.github/workflows/zap-publish-image-rdb.yml
@@ -72,7 +72,7 @@ jobs:
          # -t owasp/zap2docker-weekly zap-full-scan.py -j  \ runs for 6+ hours - times out
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Zap Report
           path: |
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Running Automated tests
         run:  |

--- a/.github/workflows/zap-publish-image-rdb.yml
+++ b/.github/workflows/zap-publish-image-rdb.yml
@@ -50,7 +50,13 @@ jobs:
           # Pull the OWASP ZAP Docker Image
           docker pull zaproxy/zap-stable
 
-          # Run OWASP ZAP Baseline Scan
+          # Run OWASP ZAP Scan
+          pwd
+          cp .github/zap/rdb.context .
+          ls
+          # Needed for Zap 
+          chmod a+rw $(pwd)
+
           docker run --network roundabout-network \
              -v "/$(pwd):/zap/wrk/:rw" \
              -t zaproxy/zap-stable zap-baseline.py -j \
@@ -61,9 +67,9 @@ jobs:
              -n rdb.context \
              -U admin
 
-         # -t owasp/zap2docker-stable zap-baseline.py -j  \  no high alerts
-         # -t owasp/zap2docker-stable zap-full-scan.py \ runs 6+ hrs and timesout, includes high alerts
-         # -t owasp/zap2docker-weekly zap-full-scan.py -j  \ runs for 6+ hours - times out
+         # -t zaproxy/zap-stable zap-baseline.py -j  \  no high alerts
+         # -t zaproxy/zap-stable zap-full-scan.py \ runs 6+ hrs and timesout, includes high alerts
+         # -t zaproxy/zap-weekly zap-full-scan.py -j  \ runs for 6+ hours - times out
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/zap-publish-image-rdb.yml
+++ b/.github/workflows/zap-publish-image-rdb.yml
@@ -48,7 +48,7 @@ jobs:
           sh -c "until curl -Is http://localhost:8000; do echo 'waiting for http://localhost:8000'; sleep 10; done"
 
           # Pull the OWASP ZAP Docker Image
-          docker pull owasp/zap2docker-stable
+          docker pull zaproxy/zap-stable
 
           # Run OWASP ZAP Full Scan
           pwd
@@ -59,7 +59,7 @@ jobs:
 
           docker run --network roundabout-network \
              -v "/$(pwd):/zap/wrk/:rw" \
-             -t owasp/zap2docker-stable zap-baseline.py -j \
+             -t zaproxy/zap-stable zap-baseline.py -j \
              -t http://django:8000 \
              -I   \
              -d \

--- a/.github/workflows/zap-publish-image-rdb.yml
+++ b/.github/workflows/zap-publish-image-rdb.yml
@@ -50,13 +50,7 @@ jobs:
           # Pull the OWASP ZAP Docker Image
           docker pull zaproxy/zap-stable
 
-          # Run OWASP ZAP Full Scan
-          pwd
-          cp .github/zap/rdb.context .
-          ls
-          # Needed for Zap 
-          chmod a+rw $(pwd)
-
+          # Run OWASP ZAP Baseline Scan
           docker run --network roundabout-network \
              -v "/$(pwd):/zap/wrk/:rw" \
              -t zaproxy/zap-stable zap-baseline.py -j \

--- a/.github/workflows/zap-publish-image-rdb.yml
+++ b/.github/workflows/zap-publish-image-rdb.yml
@@ -16,7 +16,7 @@ jobs:
     name: OWASP
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build RDB project 
         run: |
           
@@ -46,6 +46,9 @@ jobs:
           docker-compose -f docker-compose-testing.yml build
           docker-compose -f docker-compose-testing.yml up --detach
           sh -c "until curl -Is http://localhost:8000; do echo 'waiting for http://localhost:8000'; sleep 10; done"
+
+          # Pull the OWASP ZAP Docker Image
+          docker pull owasp/zap2docker-stable
 
           # Run OWASP ZAP Full Scan
           pwd

--- a/compose/local/tests/Dockerfile
+++ b/compose/local/tests/Dockerfile
@@ -8,8 +8,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils
 RUN apt-get update
 
-RUN apt-get install curl -y && apt-get install npm -y
-
 RUN apt-get install -y wget && apt install -y unzip
 
 # At root dir
@@ -35,6 +33,7 @@ RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesourc
      | tee /etc/apt/sources.list.d/nodesource.list
 RUN apt-get update
 RUN apt-get install nodejs -y
+RUN apt-get install curl -y && apt-get install npm -y
 
 # npm WARN EBADENGINE package: 'jsdom@20.0.0' with Node 12.x
 RUN npm install jsdom@19.0.0


### PR DESCRIPTION
Node.js 16.x install not installing npm. Move npm install after node.js install.

Zap no longer in Docker Hub. Change install to Github Container Registry.
Upgrade Zap to node.js 20.